### PR TITLE
OpenTelemetry instrumentation improvements

### DIFF
--- a/otomi-quickstart-k8s-deployment-otel/Chart.yaml
+++ b/otomi-quickstart-k8s-deployment-otel/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otomi-quickstart-k8s-deployment-otel
 description: Otomi provided quick start Helm chart
-version: 1.0.0
+version: 1.1.0
 appVersion: "2.0.0"
 icon: https://otomi.io/otomi-charts/icons/otel.png

--- a/otomi-quickstart-k8s-deployment-otel/README.md
+++ b/otomi-quickstart-k8s-deployment-otel/README.md
@@ -81,4 +81,5 @@ To see traces:
 | `configmap.data` | Key value pairs stored in the configmap                                                                        | `{}`            |
 | `instrumentation.enabled` | Enable instrumentation to create instrumentation resources and add required annotations               | `true`          |
 | `instrumentation.language` | The Language libraries used for instrumentation                                                      | `java`          |
+| `instrumentation.image` | The image used for auto-instrumentation | `""`
 | `sampler.type` | Defines sampling configuration                                                                                   | `always_on`     |

--- a/otomi-quickstart-k8s-deployment-otel/templates/instrumentation.yaml
+++ b/otomi-quickstart-k8s-deployment-otel/templates/instrumentation.yaml
@@ -25,6 +25,9 @@ spec:
     {{- with .Values.instrumentation.extraEnv }}
     {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- if .Values.instrumentation.image -}}
+    image: {{ .Values.instrumentation.image }}
+    {{- end -}}
   {{- end }}
   {{- if eq .Values.instrumentation.language "dotnet" }}
   dotnet:
@@ -36,6 +39,9 @@ spec:
     {{- with .Values.instrumentation.extraEnv }}
     {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- if .Values.instrumentation.image -}}
+    image: {{ .Values.instrumentation.image }}
+    {{- end -}}
   {{- end }}
   {{- if eq .Values.instrumentation.language "python" }}
   python:
@@ -47,6 +53,9 @@ spec:
     {{- with .Values.instrumentation.extraEnv }}
     {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- if .Values.instrumentation.image -}}
+    image: {{ .Values.instrumentation.image }}
+    {{- end -}}
   {{- end }}
   {{- if eq .Values.instrumentation.language "nodejs" }}
   nodejs:
@@ -56,5 +65,8 @@ spec:
     {{- with .Values.instrumentation.extraEnv }}
     {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- if .Values.instrumentation.image -}}
+    image: {{ .Values.instrumentation.image }}
+    {{- end -}}
   {{- end }}
 {{- end }}

--- a/otomi-quickstart-k8s-deployment-otel/templates/instrumentation.yaml
+++ b/otomi-quickstart-k8s-deployment-otel/templates/instrumentation.yaml
@@ -25,9 +25,9 @@ spec:
     {{- with .Values.instrumentation.extraEnv }}
     {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- if .Values.instrumentation.image -}}
-    image: {{ .Values.instrumentation.image }}
-    {{- end -}}
+    {{- with .Values.instrumentation.image }}
+    image: {{ . }}
+    {{- end }}
   {{- end }}
   {{- if eq .Values.instrumentation.language "dotnet" }}
   dotnet:
@@ -39,9 +39,9 @@ spec:
     {{- with .Values.instrumentation.extraEnv }}
     {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- if .Values.instrumentation.image -}}
-    image: {{ .Values.instrumentation.image }}
-    {{- end -}}
+    {{- with .Values.instrumentation.image }}
+    image: {{ . }}
+    {{- end }}
   {{- end }}
   {{- if eq .Values.instrumentation.language "python" }}
   python:
@@ -53,9 +53,9 @@ spec:
     {{- with .Values.instrumentation.extraEnv }}
     {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- if .Values.instrumentation.image -}}
-    image: {{ .Values.instrumentation.image }}
-    {{- end -}}
+    {{- with .Values.instrumentation.image }}
+    image: {{ . }}
+    {{- end }}
   {{- end }}
   {{- if eq .Values.instrumentation.language "nodejs" }}
   nodejs:
@@ -65,8 +65,8 @@ spec:
     {{- with .Values.instrumentation.extraEnv }}
     {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- if .Values.instrumentation.image -}}
-    image: {{ .Values.instrumentation.image }}
-    {{- end -}}
+    {{- with .Values.instrumentation.image }}
+    image: {{ . }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/otomi-quickstart-k8s-deployment-otel/templates/instrumentation.yaml
+++ b/otomi-quickstart-k8s-deployment-otel/templates/instrumentation.yaml
@@ -18,35 +18,43 @@ spec:
   exporter:
     endpoint: http://otel-collector-collector.otel.svc.cluster.local:4317
   {{- if eq .Values.instrumentation.language "java" }}
-  {{- with .Values.instrumentation.extraEnv }}
   java:
     env:
+      - name: OTEL_METRICS_EXPORTER
+        value: none
+    {{- with .Values.instrumentation.extraEnv }}
     {{- toYaml . | nindent 6 }}
-  {{- end }}
+    {{- end }}
   {{- end }}
   {{- if eq .Values.instrumentation.language "dotnet" }}
   dotnet:
     env: 
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://otel-collector-collector.otel.svc.cluster.local:4318
+      - name: OTEL_METRICS_EXPORTER
+        value: none
     {{- with .Values.instrumentation.extraEnv }}
     {{- toYaml . | nindent 6 }}
     {{- end }}
   {{- end }}
   {{- if eq .Values.instrumentation.language "python" }}
   python:
-    env: 
+    env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://otel-collector-collector.otel.svc.cluster.local:4318
+      - name: OTEL_METRICS_EXPORTER
+        value: none
     {{- with .Values.instrumentation.extraEnv }}
     {{- toYaml . | nindent 6 }}
     {{- end }}
   {{- end }}
   {{- if eq .Values.instrumentation.language "nodejs" }}
-  {{- with .Values.instrumentation.extraEnv }}
   nodejs:
     env:
+      - name: OTEL_METRICS_EXPORTER
+        value: none
+    {{- with .Values.instrumentation.extraEnv }}
     {{- toYaml . | nindent 6 }}
-  {{- end }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/otomi-quickstart-k8s-deployment-otel/values.yaml
+++ b/otomi-quickstart-k8s-deployment-otel/values.yaml
@@ -243,3 +243,5 @@ instrumentation:
   #     value: false
   #   - name: OTEL_INSTRUMENTATION_REDISCALA_ENABLED
   #     value: false
+  ## @param image Image for auto-instrumentation. The operator release provides certain default images, which can be overridden for improving compatibility with newer versions of Python, Java etc.
+  image: ""

--- a/otomi-quickstart-k8s-deployment-otel/values.yaml
+++ b/otomi-quickstart-k8s-deployment-otel/values.yaml
@@ -235,7 +235,7 @@ instrumentation:
     ## For instance for parentbased_traceidratio sampler type it is a number in range [0..1] e.g. 0.25.
     # argument: "0.25"
   language: java
-  ## @param extraEnv Additional variables. By default, the .NET auto-instrumentation ships with many instrumentation libraries. This makes instrumentation easy, but could result in too much or unwanted data. 
+  ## @param extraEnv Additional variables. By default, the auto-instrumentation ships with many instrumentation libraries. This makes instrumentation easy, but could result in too much or unwanted data. 
   ## If there are any libraries you do not want to use you can set the OTEL_DOTNET_AUTO_[SIGNAL]_[NAME]_INSTRUMENTATION_ENABLED=false 
   ## where [SIGNAL] is the type of the signal and [NAME] is the case-sensitive name of the library.
   # extraEnv:


### PR DESCRIPTION
This PR provides two enhancements to the `k8s-deployment-otel` templates.

* For auto-instrumentation, the image can be set (keeping the operator default if empty). Using newer images can improve compatibility with libraries used in deployed workloads. For example, the default Python auto-instrumentation strictly requires `importlib-metadata==6.0.0`, which is more relaxed in newer versions.
* Exporting metrics is disabled in the instrumentation, as the OpenTelemetry collector is currently not configured to process metrics and therefore does not provide an endpoint for them. This has lead to 404 errors reported in the application logs of Python apps.