### PR TITLE
feat: added optional initContainers to workload templates

### DIFF
--- a/otomi-quickstart-k8s-deployment-otel/Chart.yaml
+++ b/otomi-quickstart-k8s-deployment-otel/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otomi-quickstart-k8s-deployment-otel
 description: Otomi provided quick start Helm chart
-version: 1.1.0
+version: 1.1.1
 appVersion: "2.0.0"
 icon: https://otomi.io/otomi-charts/icons/otel.png

--- a/otomi-quickstart-k8s-deployment-otel/templates/deployment.yaml
+++ b/otomi-quickstart-k8s-deployment-otel/templates/deployment.yaml
@@ -84,6 +84,10 @@ spec:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.volumeMounts .Values.configmap.create }}
       volumes:
         {{- if .Values.configmap.create }}

--- a/otomi-quickstart-k8s-deployment-otel/values.yaml
+++ b/otomi-quickstart-k8s-deployment-otel/values.yaml
@@ -150,6 +150,17 @@ args: []
   # - --metric-value=40
   # - --port=8080
 
+## @param initContainers A list of initContainers to add to the pod
+##
+initContainers: []
+  # - name: app-setup
+  #   image: setup-image
+  #   command: 
+  #     - cmd1
+  #   volumeMounts:
+  #     - name: tmp
+  #       mountPath: /tmp
+
 ## @param VolumeMounts A list of volume mounts to be added to the pod
 ##
 volumeMounts: []

--- a/otomi-quickstart-k8s-deployment/Chart.yaml
+++ b/otomi-quickstart-k8s-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otomi-quickstart-k8s-deployment
 description: Otomi provided quick start Helm chart
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.16.0"
 icon: https://otomi.io/otomi-charts/icons/deploy.png

--- a/otomi-quickstart-k8s-deployment/templates/deployment.yaml
+++ b/otomi-quickstart-k8s-deployment/templates/deployment.yaml
@@ -79,6 +79,10 @@ spec:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.volumeMounts .Values.configmap.create }}
       volumes:
         {{- if .Values.configmap.create }}

--- a/otomi-quickstart-k8s-deployment/values.yaml
+++ b/otomi-quickstart-k8s-deployment/values.yaml
@@ -149,6 +149,17 @@ args: []
   # - --metric-value=40
   # - --port=8080
 
+## @param initContainers A list of initContainers to add to the pod
+##
+initContainers: []
+  # - name: app-setup
+  #   image: setup-image
+  #   command: 
+  #     - cmd1
+  #   volumeMounts:
+  #     - name: tmp
+  #       mountPath: /tmp
+
 ## @param VolumeMounts A list of volume mounts to be added to the container
 ##
 volumeMounts: []

--- a/otomi-quickstart-k8s-deployments-canary/Chart.yaml
+++ b/otomi-quickstart-k8s-deployments-canary/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otomi-quickstart-k8s-deployments-canary
 description: Otomi provided quick start Helm chart
-version: 1.0.0
+version: 1.0.1
 appVersion: "2.0.0"
 icon: https://otomi.io/otomi-charts/icons/canary.png

--- a/otomi-quickstart-k8s-deployments-canary/templates/deployment-v1.yaml
+++ b/otomi-quickstart-k8s-deployments-canary/templates/deployment-v1.yaml
@@ -80,6 +80,10 @@ spec:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
+      {{- with .Values.versionOne.initContainers }}
+      initContainers:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.volumeMounts .Values.versionOne.configmap.create }}
       volumes:
         {{- if .Values.versionOne.configmap.create }}

--- a/otomi-quickstart-k8s-deployments-canary/templates/deployment-v2.yaml
+++ b/otomi-quickstart-k8s-deployments-canary/templates/deployment-v2.yaml
@@ -80,6 +80,10 @@ spec:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
+      {{- with .Values.versionTwo.initContainers }}
+      initContainers:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.volumeMounts .Values.versionTwo.configmap.create }}
       volumes:
         {{- if .Values.versionTwo.configmap.create }}

--- a/otomi-quickstart-k8s-deployments-canary/values.yaml
+++ b/otomi-quickstart-k8s-deployments-canary/values.yaml
@@ -57,6 +57,16 @@ versionOne:
   env: []
     # - name: TARGET
     #   value: VALUE
+  ## @param initContainers A list of initContainers to add to the pod
+  ##
+  initContainers: []
+    # - name: app-setup
+    #   image: setup-image
+    #   command: 
+    #     - cmd1
+    #   volumeMounts:
+    #     - name: tmp
+    #       mountPath: /tmp    
 
 versionTwo:
   ## @param image.repository your v2 image repository
@@ -105,6 +115,16 @@ versionTwo:
     # - --metric-name=custom_prometheus
     # - --metric-value=40
     # - --port=8080
+  ## @param initContainers A list of initContainers to add to the pod
+  ##
+  initContainers: []
+    # - name: app-setup
+    #   image: setup-image
+    #   command: 
+    #     - cmd1
+    #   volumeMounts:
+    #     - name: tmp
+    #       mountPath: /tmp    
   ## @param env Environment variables for containers
   ##
   env: []


### PR DESCRIPTION
This PR adds an `initContainers` value to user-defined deployments. Having those is often required, or at least more practical than other methods (e.g. Jobs) when doing initialization tasks (database migration, extracting static files etc).