### PR TITLE
fix: hardcoded mtls namespace

### DIFF
--- a/otomi-quickstart-rabbitmq/templates/istio.yaml
+++ b/otomi-quickstart-rabbitmq/templates/istio.yaml
@@ -1,4 +1,5 @@
 {{- $ := . }}
+{{- $clusterName := include "rabbitmq.fullname" $ }}
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: ServiceEntry
@@ -21,7 +22,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: rabbitmq-mtls
+  name: {{ $clusterName }}-mtls
   namespace: {{ $.Release.Namespace }}
 spec:
   host: {{ include "rabbitmq.fullname" $ }}-nodes.{{$.Release.Namespace}}.svc.cluster.local

--- a/otomi-quickstart-rabbitmq/templates/istio.yaml
+++ b/otomi-quickstart-rabbitmq/templates/istio.yaml
@@ -22,7 +22,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: rabbitmq-mtls
-  namespace: team-demo
+  namespace: {{ $.Release.Namespace }}
 spec:
   host: {{ include "rabbitmq.fullname" $ }}-nodes.{{$.Release.Namespace}}.svc.cluster.local
   trafficPolicy:


### PR DESCRIPTION
This PR fixes that the mlts for rabbitmq is trying to be added to team-demo instead of it's own team namespace.