### PR TITLE
fix: change icon urls

### DIFF
--- a/otomi-quickstart-k8s-deployment-otel/Chart.yaml
+++ b/otomi-quickstart-k8s-deployment-otel/Chart.yaml
@@ -3,4 +3,4 @@ name: otomi-quickstart-k8s-deployment-otel
 description: Otomi provided quick start Helm chart
 version: 1.1.1
 appVersion: "2.0.0"
-icon: https://otomi.io/otomi-charts/icons/otel.png
+icon: https://linode.github.io/apl-charts/icons/otel.png

--- a/otomi-quickstart-k8s-deployment/Chart.yaml
+++ b/otomi-quickstart-k8s-deployment/Chart.yaml
@@ -3,4 +3,4 @@ name: otomi-quickstart-k8s-deployment
 description: Otomi provided quick start Helm chart
 version: 1.0.1
 appVersion: "1.16.0"
-icon: https://otomi.io/otomi-charts/icons/deploy.png
+icon: https://linode.github.io/apl-charts/icons/deploy.png

--- a/otomi-quickstart-k8s-deployments-canary/Chart.yaml
+++ b/otomi-quickstart-k8s-deployments-canary/Chart.yaml
@@ -3,4 +3,4 @@ name: otomi-quickstart-k8s-deployments-canary
 description: Otomi provided quick start Helm chart
 version: 1.0.1
 appVersion: "2.0.0"
-icon: https://otomi.io/otomi-charts/icons/canary.png
+icon: https://linode.github.io/apl-charts/icons/canary.png

--- a/otomi-quickstart-knative-service/Chart.yaml
+++ b/otomi-quickstart-knative-service/Chart.yaml
@@ -4,4 +4,4 @@ description: Otomi provided quick start Helm chart
 type: application
 version: 1.0.0
 appVersion: "2.0.0"
-icon: https://otomi.io/otomi-charts/icons/knative.png
+icon: https://linode.github.io/apl-charts/icons/knative.png

--- a/otomi-quickstart-postgresql/Chart.yaml
+++ b/otomi-quickstart-postgresql/Chart.yaml
@@ -4,4 +4,4 @@ description: Otomi provided quick start Helm chart
 type: application
 version: 1.0.0
 appVersion: "2.0.0"
-icon: https://otomi.io/otomi-charts/icons/postgresql.png
+icon: https://linode.github.io/apl-charts/icons/postgresql.png

--- a/otomi-quickstart-rabbitmq/Chart.yaml
+++ b/otomi-quickstart-rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ version: 0.1.0
 # It is recommended to use it with quotes.
 appVersion: "1.16.0"
 
-icon: https://otomi.io/otomi-charts/icons/rabbitmq.png
+icon: https://linode.github.io/apl-charts/icons/rabbitmq.png


### PR DESCRIPTION
This PR changes the icon urls to the github pages url of the new apl-charts repo