### PR TITLE
fix: imagepullsecret not default and scale to zero

### DIFF
--- a/quickstart-knative-service/README.md
+++ b/quickstart-knative-service/README.md
@@ -6,7 +6,7 @@ The `quickstart-knative-service` Helm chart can be used to create a Knative `Ser
 
 The Catalog is a library of curated Helm charts to create Kubernetes resources. By default the Catalog contains a set of Helm charts provided by Application Platform for LKE to get started quickly, but they can also be modified depending on your requirements or be removed from the Catalog. The contents of the Catalog and the RBAC configuration (which Team can use which Helm chart) are managed by the platform administrator.
 
-## Using Public vs. private registries
+## Using public vs. private registries
 
 To enable Knative to pull images from public repositories, the `harbor-pullsecret` is not added to the `serviceAccount`. Add the `harbor-pullsecret` to pull images from the Team's private image repository.
 

--- a/quickstart-knative-service/README.md
+++ b/quickstart-knative-service/README.md
@@ -6,12 +6,17 @@ The `quickstart-knative-service` Helm chart can be used to create a Knative `Ser
 
 The Catalog is a library of curated Helm charts to create Kubernetes resources. By default the Catalog contains a set of Helm charts provided by Application Platform for LKE to get started quickly, but they can also be modified depending on your requirements or be removed from the Catalog. The contents of the Catalog and the RBAC configuration (which Team can use which Helm chart) are managed by the platform administrator.
 
+## Using Public vs. private registries
+
+To enable Knative to pull images from public repositories, the `harbor-pullsecret` is not added to the `serviceAccount`. Add the `harbor-pullsecret` to pull images from the Team's private image repository.
+
 ## How to use this quick start
 
 1. Create a Build and copy the image repository name of the build (see list of builds)
 2. Go to the `values` tab and fill in a name for your Workload
 3. Add the image repository name of the Build to the `image.repository` parameter value
 4. Add the tag of the Build to the `image.tag` parameter value
+5. Add the `harbor-pullsecret` pull secret to the service account
 5. Optional: Change other parameter values as required
 
 ## Prerequisites
@@ -41,11 +46,11 @@ To use this Helm chart:
 |------------------|----------------------------------------------------------------------------------------------------------------|-----------------|
 | `pullPolicy` | Image pull policy. Choose between `always`, `never` or (default) `IfNotPresent`                                    | `IfNotPresent`  |
 | `env` | Environment variables for containers                                                                                      | `[]`            |
-| `podAnnotations` | Additional Annotations for pods                                                                                | `{}`            |
+| `annotations` | Additional Annotations. See https://knative.dev/docs/serving/autoscaling/ for all auto scaling annotations        | `{}`            |
 | `podLabels` | Additional labels for pods                                                                                          | `{}`            |
 | `commonLabels` | Additional labels for all resources                                                                              | `{}`            |
 | `serviceAccount.annotations` | Annotations for the service account                                                                | `{}`            |
-| `serviceAccount.imagePullSecrets` | Image pull secrets. Only add when using external registries (not the local harbor).           | `[]`            |
+| `serviceAccount.imagePullSecrets` | Image pull secrets. Configure when using the Team local Harbor repository                     | `[]`            |
 | `livenessProbe` | Container liveness probe                                                                                        | `path=/` `port=http1` |
 | `readinessProbe` | Container readiness probe                                                                                      | `{}`            |
 | `containerSecurityContext` | Container security context                                                                           | `{}`            |

--- a/quickstart-knative-service/templates/knative-svc.yaml
+++ b/quickstart-knative-service/templates/knative-svc.yaml
@@ -12,12 +12,9 @@ metadata:
 spec:
   template:
     metadata:
-      annotations:
-        autoscaling.knative.dev/min-scale: "{{ .Values.autoscaling.minReplicas }}"
-        autoscaling.knative.dev/max-scale: "{{ .Values.autoscaling.maxReplicas }}"
-        {{- with .Values.podAnnotations }}
-        {{- . | toYaml | nindent 8 }}
-        {{- end }}
+      {{- with .Values.annotations }}
+      annotations: {{- toYaml | nindent 8 }}
+      {{- end }}
       {{- with .Values.podLabels }}
       labels:
       {{- toYaml . | nindent 8 }}

--- a/quickstart-knative-service/templates/serviceaccount.yaml
+++ b/quickstart-knative-service/templates/serviceaccount.yaml
@@ -9,9 +9,8 @@ metadata:
   {{- with .Values.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
-imagePullSecrets:
-- name: harbor-pullsecret
 {{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
 {{- toYaml . | nindent 2 }}
 {{- end }}
 automountServiceAccountToken: false

--- a/quickstart-knative-service/values.yaml
+++ b/quickstart-knative-service/values.yaml
@@ -18,10 +18,22 @@ env: []
   # - name: TARGET
   #   value: VALUE
 
-## @param annotations Annotations for pods
-## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+## @param annotations for Knative
 ##
-podAnnotations: {}
+annotations: {}
+  ## See https://knative.dev/docs/serving/autoscaling/ for all autoscaling annotations
+  ## Use HPA instead of KPA (default)
+  # autoscaling.knative.dev/class: "kpa.autoscaling.knative.dev"
+  ## Configure metrics
+  # autoscaling.knative.dev/metric: "concurrency"
+  # autoscaling.knative.dev/target-utilization-percentage: "70"
+  ## Scale to zero
+  ## Default scale-to-zero-grace-period is set to 60s
+  ## Scale to zero last retention period
+  # autoscaling.knative.dev/scale-to-zero-pod-retention-period: "1m5s"
+  ## Stable window
+  ## Default stable-window is set to 600s
+  # autoscaling.knative.dev/window: "40s"
 
 ## @param labels Additional labels for pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -32,15 +44,6 @@ podLabels: {}
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 commonLabels: {}
-
-## @param autoscaling Set autoscaling annotations for the Knative service
-## Will set the following annotations:
-## autoscaling.knative.dev/min-scale: "minReplicas"
-## autoscaling.knative.dev/max-scale: "maxReplicas"
-##
-autoscaling:
-  minReplicas: 0
-  maxReplicas: 10
 
 ## Pods Service Account
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -59,6 +62,8 @@ serviceAccount:
   ##   - myRegistryKeySecretName
   ##
   imagePullSecrets: []
+  ## Add the harbor-pullsecret when pulling from a private local Harbor registry
+  # - name: harbor-pullsecret
 
 ## Container liveness probe.
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes


### PR DESCRIPTION
Knative can not pull images from public repositories if a pullsecret is configured. That's why the user needs to set the pullsecret for Harbor if image needs to be pulled from the Team's private Harbor repo

The scale annotations have changed. The user can now configure all scaling options by setting desired annotations per revision. The operator defaults are added to the comments and can be overridden by the user.