### PR TITLE
fix: kfp clusterrolebinding

### DIFF
--- a/kfp-cluster-resources/templates/crds.yaml
+++ b/kfp-cluster-resources/templates/crds.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kubeflow
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1542,14 +1537,3 @@ rules:
   verbs:
   - approve
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kubeflow-pipelines-cache-deployer-clusterrolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kubeflow-pipelines-cache-deployer-clusterrole
-subjects:
-- kind: ServiceAccount
-  name: kubeflow-pipelines-cache-deployer-sa

--- a/spin-app/templates/_helpers.tpl
+++ b/spin-app/templates/_helpers.tpl
@@ -28,4 +28,5 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ include "spinapp.fullname" . }}
 app.kubernetes.io/owner: {{ .Release.Namespace }}
 otomi.io/app: {{ include "spinapp.fullname" . }}
+sidecar.istio.io/inject: "false"
 {{- end }}

--- a/spin-app/templates/spin-app.yaml
+++ b/spin-app/templates/spin-app.yaml
@@ -10,14 +10,16 @@ spec:
   image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
   executor: containerd-shim-spin
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.runtimeConfig }}
+  runtimeConfig: {{- . | toYaml | nindent 4 }}
+  {{- end }}
   enableAutoscaling: {{ .Values.enableAutoscaling }}
-  podLabels:
-    sidecar.istio.io/inject: "false"
+  podLabels: {{- include "spinapp.labels" . | nindent 4 }}
   {{- with .Values.resources }}
   resources: {{- . | toYaml | nindent 4 }}
   {{- end }}
   {{- with .Values.env }}
-  variables: {{- toYaml . | nindent 12 }}
+  variables: {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.volumeMounts }}
   volumeMounts:

--- a/spin-app/values.yaml
+++ b/spin-app/values.yaml
@@ -15,6 +15,9 @@ image:
 ##
 replicaCount: 2
 
+## RuntimeConfig defines configuration to be applied at runtime for this app.
+runtimeConfig: {}
+
 ## @param env Environment variables for the container
 ##
 env: []


### PR DESCRIPTION
This PR:
- provides a fix for the crb which was created by the `kfp-cluster-resources` but should be created by the `kubeflow-pipelines`
- provides a fix for a wrong indent in the `spin-app` template
- adds extra parameters for a `spinApp`