### PR TITLE
fix: refer to the default team imagePullsecret in knative-service Hel…

### DIFF
--- a/knative-service/templates/serviceaccount.yaml
+++ b/knative-service/templates/serviceaccount.yaml
@@ -9,8 +9,9 @@ metadata:
   {{- with .Values.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- with .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
+  - name: harbor-pullsecret
+{{- with .Values.serviceAccount.imagePullSecrets }}
 {{- toYaml . | nindent 2 }}
 {{- end }}
 automountServiceAccountToken: false


### PR DESCRIPTION
## 📌 Summary

This code change ensures compatibility of Knative-service chart with the container images that are hosted in Harbor team project.

## 🔍 Reviewer Notes
This chart has been tested against container images from both Harbor private registry and 3rd part public registry.
