### PR TITLE
feat: updated readme to remove classic queue options

### DIFF
--- a/rabbitmq-cluster/README.md
+++ b/rabbitmq-cluster/README.md
@@ -65,16 +65,7 @@ Depending on the Queue type you can set different policy definitions. To set a d
 
 ```
 policies:
-  - name: "my-policy1"
-    pattern: ".*"
-    definition:
-      dead-letter-exchange: "cc"
-      ha-mode: "all"
-    spec:
-      applyTo: "classic_queues"
-      priority: 1
-      vhost: "/"
-  - name: my-policy2
+  - name: my-policy1
     pattern: .*
     definition:
       dead-letter-exchange: cc
@@ -94,31 +85,19 @@ policies:
 | `dead-letter-routing-key` | The routing keys (including CC keys but excluding  BCC ones) the message was published with.                 | `string`            |
 | `message-ttl` | How long a message published to a queue can live before it is discarded (milliseconds).                                                                               | `number`            |
 | `consumer-timeout` | If a consumer does not ack its delivery for more than the timeout value (30 minutes by default), its channel will be closed with a PRECONDITION_FAILED channel exception.                                                                                | `number`            |
-
-##### Queues [Classic]
-| Name             | Description                                                                                                    | Value           |
-|------------------|----------------------------------------------------------------------------------------------------------------|-----------------|
-| `ha-mode` | One of all (mirror to all nodes in the cluster), exactly (mirror to a set number of nodes) or nodes (mirror to an explicit list of nodes). If you choose one of the latter two, you must also set ha-params.                                     | `[all, exactly, nodes]`  |
-| `ha-params` | Absent if ha-mode is all, a number if ha-mode is exactly, or a list of strings if ha-mode is nodes.                                                                                       | `number | string[]`            |
-| `ha-sync-mode` | [manual, automatic]                                                                                | `[manual, automatic]`            |
-| `ha-promote-on-shutdown` |  Provides an option to promote a node containing the queue as the master queue node. Is triggered when the node is shutdown gracefully.                                                    | `[when-synced, always]`            |
-| `ha-promote-on-failure` | Provides an option to promote a node containing the queue as the master queue node. Is triggered when the node fails                                                                        | `[when-synced, always]`            |
-| `queue-version` | Set the queue version. Defaults to version 1. Version 1 has a journal-based index that embeds small messages. Version 2 has a different index which improves memory usage and performance in many scenarios, as well as a per-queue store for messages that were previously embedded. | `number`            |
-| `queue-master-locator` | The master queue node is automatically assigned using the rabbitmq node with less masters. `Min-masters`: Selects the master node as the one with the least running master queues. `Client-local`: Selects the queue master node as the local node on which the queue is being declared. `Random`: Selects the queue master node based on random selection.        | `[min-masters, client-local, random]`            |
+| `queue-leader-locator` | Set the rule by which the queue leader is located when declared on a cluster of nodes. Valid values are client-local (default) and balanced.                                                                               | `[client-local, balanced]`            |
 
 ##### Queues [Quorum]
 | Name             | Description                                                                                                    | Value           |
 |------------------|----------------------------------------------------------------------------------------------------------------|-----------------|
 | `delivery-limit` | The number of allowed unsuccessful delivery attempts. Once a message has been delivered unsuccessfully more than this many times it will be dropped or dead-lettered, depending on the queue configuration.                                     | `number`  |
 | `dead-letter-strategy` | Valid values are at-most-once or at-least-once. It defaults to at-most-once. This setting is understood only by quorum queues. If at-least-once is set, Overflow behaviour must be set to reject-publish. Otherwise, dead letter strategy will fall back to at-most-once. | `[at-most-once, at-least-once]` |
-| `queue-leader-locator` | Set the rule by which the queue leader is located when declared on a cluster of nodes. Valid values are client-local (default) and balanced.                                                                               | `[client-local, balanced]`            |
 
 ##### Streams
 | Name             | Description                                                                                                    | Value           |
 |------------------|----------------------------------------------------------------------------------------------------------------|-----------------|
 | `max-age` | Use a number + letter to set the data retention, (Y=Years, M=Months, D=Days, h=hours, m=minutes, s=seconds), Ex: 1h = configures the stream to only keep the last 1 hour of received messages                                    | `string`  |
 | `stream-max-segment-size-bytes` | Total segment size for stream segments on disk. | `number` |
-| `queue-leader-locator` | Set the rule by which the queue leader is located when declared on a cluster of nodes. Valid values are client-local (default) and balanced.                                                                               | `[client-local, balanced]`            |
 
 ##### Exchanges
 | Name             | Description                                                                                                    | Value           |


### PR DESCRIPTION
This PR updates the readme so that classic queue specific options are removed since they are removed.